### PR TITLE
Counter with shared state between clients

### DIFF
--- a/lib/live_view_counter_web/live/counter.ex
+++ b/lib/live_view_counter_web/live/counter.ex
@@ -1,16 +1,27 @@
 defmodule LiveViewCounterWeb.Counter do
   use LiveViewCounterWeb, :live_view
 
+  @topic "count"
+
   def mount(_params, _session, socket) do
+    LiveViewCounterWeb.Endpoint.subscribe(@topic)
     {:ok, assign(socket, :val, 0)}
   end
 
   def handle_event("inc", _, socket) do
-    {:noreply, update(socket, :val, &(&1 + 1))}
+    new_state = update(socket, :val, &(&1 + 1))
+    LiveViewCounterWeb.Endpoint.broadcast_from(self(), @topic, "inc", new_state.assigns)
+    {:noreply, new_state}
   end
 
   def handle_event("dec", _, socket) do
-    {:noreply, update(socket, :val, &(&1 - 1))}
+    new_state = update(socket, :val, &(&1 - 1))
+    LiveViewCounterWeb.Endpoint.broadcast_from(self(), @topic, "dec", new_state.assigns)
+    {:noreply, new_state}
+  end
+
+  def handle_info(msg, socket) do
+    {:noreply, assign(socket, :val, msg.payload.val)}
   end
 
   def render(assigns) do


### PR DESCRIPTION
One of the biggest selling points of using Phoenix to build web apps is the built-in support for WebSockets in the form of "channels". Phoenix Channels allow us to effortlessly sync data between clients and servers with minimal overhead.